### PR TITLE
fix: UltraHand the default key combo

### DIFF
--- a/Sources/OCBundle/config/ultrahand/config.ini
+++ b/Sources/OCBundle/config/ultrahand/config.ini
@@ -12,4 +12,4 @@ hide_pcb_temp = true
 hide_soc_temp = true
 default_menu = overlays
 in_overlay = false
-key_combo = ZL+ZR+Down
+key_combo = ZL+ZR+DDOWN


### PR DESCRIPTION
UltraHand is opening by LR+LR instead of the specified default LR+LR+Down. Moreover changing the not existing key combo causes Atmposhere crash. ZL+ZR+DDOWN works as expected.